### PR TITLE
Fix predicted maintenance date sensor rapidly updating

### DIFF
--- a/custom_components/device_maintenance_monitor/sensor.py
+++ b/custom_components/device_maintenance_monitor/sensor.py
@@ -85,7 +85,7 @@ MAINTENANCE_SENSORS: list[MaintenanceSensorEntityDescription] = [
     MaintenanceSensorEntityDescription(
         key=STATE_PREDICTED_MAINTENANCE_DATE,
         device_class=SensorDeviceClass.DATE,
-        value_fn=lambda logic: logic.predicted_maintenance_date,
+        value_fn=lambda logic: logic.predicted_maintenance_date.date(),
     ),
 ]
 


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed an issue where the predicted maintenance date sensor was updating too frequently by ensuring it only returns the date part, not the time.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>sensor.py</strong><dd><code>Fix rapid updates of predicted maintenance date sensor</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

custom_components/device_maintenance_monitor/sensor.py

<li>Modified the <code>value_fn</code> lambda function to return only the date part of <br><code>predicted_maintenance_date</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/rafael-zilberman/device-maintenance-monitor-custom-component/pull/31/files#diff-8b9f500fd21aa3aeac676222e84b69cf4f624c53a8fbccc22594501fc3bc2ed2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

